### PR TITLE
Finish the web views

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,6 +24,7 @@ per-file-ignores =
     tests/forms/*.py:D
     tests/interfaces/*.py:D,
     tests/models/*.py:D
+    tests/views/*.py:D
     tests/test_checks.py:D
 
 # ...and limit flake8 to the project's very own source code

--- a/calingen/models/event.py
+++ b/calingen/models/event.py
@@ -334,7 +334,7 @@ class Event(models.Model):
 class EventForm(forms.ModelForm):
     """Used to validate input for creating and updating `Event` instances."""
 
-    start = SplitDateTimeOptionalField()
+    start = SplitDateTimeOptionalField(help_text=Event.start.field.help_text)
 
     class Meta:  # noqa: D106
         model = Event

--- a/calingen/models/queryset.py
+++ b/calingen/models/queryset.py
@@ -36,7 +36,7 @@ class CalingenQuerySet(QuerySet):
         Currently, this method does nothing on its own, but is kept to keep the
         app's specific QuerySets consistent.
         """
-        return self
+        return self  # pragma: nocover
 
     def filter_by_user(self, user):
         """Return a queryset filtered by the ``owner`` attribute.
@@ -59,4 +59,6 @@ class CalingenQuerySet(QuerySet):
         ensuring `row-level permissions`, because only owners are allowed to
         view (and modify) their events.
         """
-        raise NotImplementedError("Must be implemented by actual QuerySet")
+        raise NotImplementedError(
+            "Must be implemented by actual QuerySet"
+        )  # pragma: nocover

--- a/calingen/templates/calingen/app_base.html
+++ b/calingen/templates/calingen/app_base.html
@@ -95,8 +95,10 @@
           {% if profile_id %}
           <li><a href="{% url "profile" profile_id %}">Profile</a></li>
           <li><a href="{% url "profile-update" profile_id %}">Update Profile</a></li>
-          {% endif %}
+          <li><a href="{% url "profile-delete" profile_id %}">Delete Profile</a></li>
+          {% else %}
           <li><a href="{% url "profile-add" %}">Add Profile</a></li>
+          {% endif %}
         </ul>
       </div>
       <div>

--- a/calingen/templates/calingen/app_base.html
+++ b/calingen/templates/calingen/app_base.html
@@ -77,11 +77,12 @@
         padding: 0.25em 1em;
         margin: 0.25em 0.25rem;
       }
-      form.calingen-form button[type="submit"] {
+      form.calingen-form button.submit {
         background-color: #060;
         color: #eee;
       }
-      form.calingen-form button[type="reset"] {
+      form.calingen-form button.cancel,
+      form.calingen-form button.danger {
         background-color: #900;
         color: #eee;
       }

--- a/calingen/templates/calingen/calender_entry_list_year.html
+++ b/calingen/templates/calingen/calender_entry_list_year.html
@@ -3,7 +3,12 @@
 {% block page_title %}Base: EventListYear{% endblock page_title %}
 
 {% block main %}
-<h2>Event List for Year</h2>
+<h2>
+  Event List for Year
+  <a href="{% url "calender-entry-list-year" profile_id target_year|add:"-1" %}">&#171;</a>
+  {{ target_year }}
+  <a href="{% url "calender-entry-list-year" profile_id target_year|add:"1" %}">&#187;</a>
+</h2>
 
 <section>
   <table class="list_view">

--- a/calingen/templates/calingen/event_confirm_delete.html
+++ b/calingen/templates/calingen/event_confirm_delete.html
@@ -3,11 +3,11 @@
 {% block page_title %}Event: EventDeleteView{% endblock page_title %}
 
 {% block main %}
-<form method="post">{% csrf_token %}
+<form method="post" class="calingen-form">{% csrf_token %}
   <p>Are you sure you want to delete this event?</p>
   <p>
     <strong>{{ event_item.title }}</strong>: {{ event_item.timestamp|date:"c" }} - {{ event_item.get_category_display }}
   </p>
-  <input type="submit" value="Confirm" />
+  <button type="submit" class="danger">Yes, I want to delete this Event!</button>
 </form>
 {% endblock main %}

--- a/calingen/templates/calingen/event_create.html
+++ b/calingen/templates/calingen/event_create.html
@@ -10,7 +10,7 @@
 
   {% include "calingen/includes/form.html" with form=form %}
 
-  <button type="submit">Add Event</button>
-  <button type="reset">Cancel</button>
+  <button type="submit" class="submit">Add Event</button>
+  <button type="reset" class="cancel">Cancel</button>
 </form>
 {% endblock main %}

--- a/calingen/templates/calingen/event_detail.html
+++ b/calingen/templates/calingen/event_detail.html
@@ -15,16 +15,13 @@
     </tr>
     <tr>
       <td>Start Date & Time:</td>
-      <td>{{ event_item.timestamp|date:"c" }}</td>
+      <td>{{ event_item.start|date:"c" }}</td>
     </tr>
     <tr>
       <td>Category:</td>
       <td>{{ event_item.get_category_display }} [{{ event_item.category }}]</td>
     </tr>
-    <tr>
-      <td>Owner:</td>
-      <td>{{ event_item.owner }}</td>
-    </tr>
+
     <tr>
       <td>Actions:</td>
       <td>

--- a/calingen/templates/calingen/event_update.html
+++ b/calingen/templates/calingen/event_update.html
@@ -10,7 +10,7 @@
 
   {% include "calingen/includes/form.html" with form=form %}
 
-  <button type="submit">Update Event</button>
-  <button type="reset">Cancel</button>
+  <button type="submit" class="submit">Update Event</button>
+  <button type="reset" class="cancel">Cancel</button>
 </form>
 {% endblock main %}

--- a/calingen/templates/calingen/profile_confirm_delete.html
+++ b/calingen/templates/calingen/profile_confirm_delete.html
@@ -3,8 +3,8 @@
 {% block page_title %}Profile: ProfileDeleteView{% endblock page_title %}
 
 {% block main %}
-<form method="post">{% csrf_token %}
+<form method="post" class="calingen-form">{% csrf_token %}
   <p>Are you sure you want to delete your <strong>CalInGen</strong> profile?</p>
-  <input type="submit" value="Confirm" />
+  <button type="submit" class="danger">Yes, I want to delete my Profile!</button>
 </form>
 {% endblock main %}

--- a/calingen/templates/calingen/profile_create.html
+++ b/calingen/templates/calingen/profile_create.html
@@ -10,7 +10,7 @@
 
   {% include "calingen/includes/form.html" with form=form %}
 
-  <button type="submit">Add Profile</button>
-  <button type="reset">Cancel</button>
+  <button type="submit" class="submit">Add Profile</button>
+  <button type="reset" class="cancel">Cancel</button>
 </form>
 {% endblock main %}

--- a/calingen/templates/calingen/profile_detail.html
+++ b/calingen/templates/calingen/profile_detail.html
@@ -14,6 +14,7 @@
   <li><a href="{% url "event-add" %}">add Events</a> to your profile</li>
   <li>see <a href="{% url "event-list" %}">all Events</a></li>
   <li>update your <a href="{% url "profile-update" profile_id %}">Profile Settings</a></li>
+  <li><a href="{% url "profile-delete" profile_id %}">delete</a> your Profile</li>
 </ul>
 
 {% endblock main %}

--- a/calingen/templates/calingen/profile_update.html
+++ b/calingen/templates/calingen/profile_update.html
@@ -10,7 +10,7 @@
 
   {% include "calingen/includes/form.html" with form=form %}
 
-  <button type="submit">Update Profile</button>
-  <button type="reset">Cancel</button>
+  <button type="submit" class="submit">Update Profile</button>
+  <button type="reset" class="cancel">Cancel</button>
 </form>
 {% endblock main %}

--- a/calingen/urls.py
+++ b/calingen/urls.py
@@ -40,13 +40,13 @@ urlpatterns = [
     ),
     path(
         "<int:profile_id>/events/",
-        web.CalenderEntryListYearView.as_view(),
+        web.CalenderEntryListView.as_view(),
         kwargs={"target_year": datetime.datetime.now().year},
         name="calender-entry-list-year",
     ),
     path(
         "<int:profile_id>/events/<int:target_year>/",
-        web.CalenderEntryListYearView.as_view(),
+        web.CalenderEntryListView.as_view(),
         name="calender-entry-list-year",
     ),
 ]

--- a/calingen/views/event.py
+++ b/calingen/views/event.py
@@ -10,15 +10,10 @@ from django.views import generic
 # app imports
 from calingen.models.event import Event, EventForm
 from calingen.models.profile import Profile
-from calingen.views.mixins import (
-    CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
-)
+from calingen.views.mixins import CalingenRestrictToUserMixin, ProfileIDMixin
 
 
-class EventCreateView(
-    LoginRequiredMixin, CalingenUserProfileIDMixin, generic.CreateView
-):
+class EventCreateView(LoginRequiredMixin, ProfileIDMixin, generic.CreateView):
     """Provide the generic class-based view implementation to add `Event` objects.
 
     Notes
@@ -62,7 +57,7 @@ class EventCreateView(
 class EventDeleteView(
     CalingenRestrictToUserMixin,
     LoginRequiredMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.DeleteView,
 ):
     """Provide the generic class-based view implementation to delete `Event` objects.
@@ -93,7 +88,7 @@ class EventDeleteView(
 class EventDetailView(
     CalingenRestrictToUserMixin,
     LoginRequiredMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.DetailView,
 ):
     """Provide details of a :class:`calingen.models.event.Event` instance.
@@ -121,7 +116,7 @@ class EventDetailView(
 class EventListView(
     CalingenRestrictToUserMixin,
     LoginRequiredMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.ListView,
 ):
     """Provide a list of :class:`calingen.models.event.Event` instances.
@@ -142,7 +137,7 @@ class EventListView(
 class EventUpdateView(
     CalingenRestrictToUserMixin,
     LoginRequiredMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.UpdateView,
 ):
     """Provide the generic class-based view implementation to update `Event` objects.

--- a/calingen/views/event.py
+++ b/calingen/views/event.py
@@ -10,7 +10,7 @@ from django.views import generic
 # app imports
 from calingen.models.event import Event, EventForm
 from calingen.models.profile import Profile
-from calingen.views.mixins import CalingenRestrictToUserMixin, ProfileIDMixin
+from calingen.views.mixins import ProfileIDMixin, RestrictToUserMixin
 
 
 class EventCreateView(LoginRequiredMixin, ProfileIDMixin, generic.CreateView):
@@ -55,7 +55,7 @@ class EventCreateView(LoginRequiredMixin, ProfileIDMixin, generic.CreateView):
 
 
 class EventDeleteView(
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     LoginRequiredMixin,
     ProfileIDMixin,
     generic.DeleteView,
@@ -86,7 +86,7 @@ class EventDeleteView(
 
 
 class EventDetailView(
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     LoginRequiredMixin,
     ProfileIDMixin,
     generic.DetailView,
@@ -114,7 +114,7 @@ class EventDetailView(
 
 
 class EventListView(
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     LoginRequiredMixin,
     ProfileIDMixin,
     generic.ListView,
@@ -135,7 +135,7 @@ class EventListView(
 
 
 class EventUpdateView(
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     LoginRequiredMixin,
     ProfileIDMixin,
     generic.UpdateView,

--- a/calingen/views/event.py
+++ b/calingen/views/event.py
@@ -34,7 +34,7 @@ class EventCreateView(LoginRequiredMixin, ProfileIDMixin, generic.CreateView):
     template_name_suffix = "_create"
     """Make the view use the template ``calingen/event_create.html``."""
 
-    def form_valid(self, form):
+    def form_valid(self, form):  # pragma: nocover
         """Inject the user's :class:`~calingen.models.profile.Profile` into the form.
 
         Every user does have only one :class:`~calingen.models.profile.Profile`

--- a/calingen/views/mixins.py
+++ b/calingen/views/mixins.py
@@ -11,7 +11,7 @@ from calingen.models.event import Event
 from calingen.models.profile import Profile
 
 
-class CalingenRestrictToUserMixin:
+class RestrictToUserMixin:
     """Limits the resulting queryset to objects, that belong to the current user.
 
     This mixin overwrites the view's ``get_queryset()`` method and automatically

--- a/calingen/views/mixins.py
+++ b/calingen/views/mixins.py
@@ -53,7 +53,7 @@ class CalingenRestrictToUserMixin:
         )
 
 
-class CalingenUserProfileIDMixin:
+class ProfileIDMixin:
     """Injects the :class:`~calingen.models.profile.Profile` id of the ``request.user`` into the context.
 
     This mixin uses ``get_context_data()`` to inject the ``profile_id``.

--- a/calingen/views/profile.py
+++ b/calingen/views/profile.py
@@ -13,16 +13,13 @@ from django.views import generic
 
 # app imports
 from calingen.models.profile import Profile, ProfileForm
-from calingen.views.mixins import (
-    CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
-)
+from calingen.views.mixins import CalingenRestrictToUserMixin, ProfileIDMixin
 
 
 class ProfileDetailView(
     LoginRequiredMixin,
     CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.DetailView,
 ):
     """Provide details of a :class:`calingen.models.profile.Profile` instance.
@@ -110,7 +107,7 @@ class ProfileCreateView(LoginRequiredMixin, generic.CreateView):
 class ProfileDeleteView(
     LoginRequiredMixin,
     CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.DeleteView,
 ):
     """Provide the generic class-based view implementation to delete `Profile` objects.
@@ -148,7 +145,7 @@ class ProfileDeleteView(
 class ProfileUpdateView(
     CalingenRestrictToUserMixin,
     LoginRequiredMixin,
-    CalingenUserProfileIDMixin,
+    ProfileIDMixin,
     generic.UpdateView,
 ):
     """Provide the generic class-based view implementation to add `Profile` objects.

--- a/calingen/views/profile.py
+++ b/calingen/views/profile.py
@@ -13,12 +13,12 @@ from django.views import generic
 
 # app imports
 from calingen.models.profile import Profile, ProfileForm
-from calingen.views.mixins import CalingenRestrictToUserMixin, ProfileIDMixin
+from calingen.views.mixins import ProfileIDMixin, RestrictToUserMixin
 
 
 class ProfileDetailView(
     LoginRequiredMixin,
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     ProfileIDMixin,
     generic.DetailView,
 ):
@@ -106,7 +106,7 @@ class ProfileCreateView(LoginRequiredMixin, generic.CreateView):
 
 class ProfileDeleteView(
     LoginRequiredMixin,
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     ProfileIDMixin,
     generic.DeleteView,
 ):
@@ -143,7 +143,7 @@ class ProfileDeleteView(
 
 
 class ProfileUpdateView(
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     LoginRequiredMixin,
     ProfileIDMixin,
     generic.UpdateView,

--- a/calingen/views/web.py
+++ b/calingen/views/web.py
@@ -15,12 +15,12 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.base import TemplateView
 
 # app imports
-from calingen.views.mixins import AllCalenderEntriesMixin, CalingenRestrictToUserMixin
+from calingen.views.mixins import AllCalenderEntriesMixin, RestrictToUserMixin
 
 
 class CalenderEntryListView(
     LoginRequiredMixin,
-    CalingenRestrictToUserMixin,
+    RestrictToUserMixin,
     AllCalenderEntriesMixin,
     TemplateView,
 ):

--- a/calingen/views/web.py
+++ b/calingen/views/web.py
@@ -21,7 +21,7 @@ from calingen.models.profile import Profile
 from calingen.views.mixins import CalingenRestrictToUserMixin
 
 
-class CalenderEntryListYearView(
+class CalenderEntryListView(
     LoginRequiredMixin,
     CalingenRestrictToUserMixin,
     TemplateView,

--- a/calingen/views/web.py
+++ b/calingen/views/web.py
@@ -51,9 +51,9 @@ class CalenderEntryListYearView(
 
         all_entries = CalenderEntryList()
         internal_events = Event.calingen_manager.get_calender_entry_list(
-            self.request.user
+            user=self.request.user, year=context["target_year"]
         )
-        plugin_events = profile.resolve()
+        plugin_events = profile.resolve(year=context["target_year"])
         all_entries.merge(internal_events)
         all_entries.merge(plugin_events)
         entries = all_entries.sorted()

--- a/calingen/views/web.py
+++ b/calingen/views/web.py
@@ -15,15 +15,13 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.base import TemplateView
 
 # app imports
-from calingen.interfaces.data_exchange import CalenderEntryList
-from calingen.models.event import Event
-from calingen.models.profile import Profile
-from calingen.views.mixins import CalingenRestrictToUserMixin
+from calingen.views.mixins import AllCalenderEntriesMixin, CalingenRestrictToUserMixin
 
 
 class CalenderEntryListView(
     LoginRequiredMixin,
     CalingenRestrictToUserMixin,
+    AllCalenderEntriesMixin,
     TemplateView,
 ):
     """Provide a list view of all events in a given year.
@@ -37,28 +35,3 @@ class CalenderEntryListView(
     """
 
     template_name = "calingen/calender_entry_list_year.html"
-
-    def get_context_data(self, **kwargs):
-        """Just for linting."""
-        context = super().get_context_data(**kwargs)
-
-        # get the user's profile (required to process plugins)
-        profile = Profile.calingen_manager.get_profile(self.request.user)
-
-        all_entries = CalenderEntryList()
-        internal_events = Event.calingen_manager.get_calender_entry_list(
-            user=self.request.user, year=context["target_year"]
-        )
-        plugin_events = profile.resolve(year=context["target_year"])
-        all_entries.merge(internal_events)
-        all_entries.merge(plugin_events)
-        entries = all_entries.sorted()
-
-        context["entries"] = entries
-
-        # Usually, CalingenUserProfileIDMixin provides the (required)
-        # profile_id, but as this view fetches the Profile anyway, it will be
-        # added manually
-        context["profile_id"] = profile.id
-
-        return context

--- a/calingen/views/web.py
+++ b/calingen/views/web.py
@@ -18,16 +18,12 @@ from django.views.generic.base import TemplateView
 from calingen.interfaces.data_exchange import CalenderEntryList
 from calingen.models.event import Event
 from calingen.models.profile import Profile
-from calingen.views.mixins import (
-    CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
-)
+from calingen.views.mixins import CalingenRestrictToUserMixin
 
 
 class CalenderEntryListYearView(
     LoginRequiredMixin,
     CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
     TemplateView,
 ):
     """Provide a list view of all events in a given year.
@@ -59,5 +55,10 @@ class CalenderEntryListYearView(
         entries = all_entries.sorted()
 
         context["entries"] = entries
+
+        # Usually, CalingenUserProfileIDMixin provides the (required)
+        # profile_id, but as this view fetches the Profile anyway, it will be
+        # added manually
+        context["profile_id"] = profile.id
 
         return context

--- a/tests/forms/test_fields.py
+++ b/tests/forms/test_fields.py
@@ -26,7 +26,7 @@ class CalingenListFieldTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = list_field.to_python(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual([], return_value)
 
     @mock.patch("calingen.forms.fields.CharField")
@@ -38,7 +38,7 @@ class CalingenListFieldTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = list_field.to_python("foo")
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(["foo"], return_value)
 
     @mock.patch("calingen.forms.fields.CharField")
@@ -50,7 +50,7 @@ class CalingenListFieldTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = list_field.to_python("foo, bar")
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(["foo", "bar"], return_value)
 
 

--- a/tests/forms/test_widgets.py
+++ b/tests/forms/test_widgets.py
@@ -26,7 +26,7 @@ class PluginWidgetTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = widget.decompress(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, [None, None])
 
     @mock.patch("calingen.forms.widgets.MultiWidget")
@@ -39,7 +39,7 @@ class PluginWidgetTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = widget.decompress(test_value)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, ["foo", []])
 
     @mock.patch("calingen.forms.widgets.MultiWidget")
@@ -52,7 +52,7 @@ class PluginWidgetTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = widget.decompress(test_value)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, [[], "foo"])
 
     @mock.patch("calingen.forms.widgets.MultiWidget")
@@ -65,5 +65,5 @@ class PluginWidgetTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = widget.decompress(test_value)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, ["foo", "bar"])

--- a/tests/interfaces/test_plugin_api.py
+++ b/tests/interfaces/test_plugin_api.py
@@ -27,7 +27,7 @@ class EventProviderTest(CalingenTestCase):
         class EventProviderTestImplementation(EventProvider):
             title = "do-not-care"
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(len(EventProvider.plugins), already_present_plugins + 1)
 
     def test_list_available_plugins(self):
@@ -42,7 +42,7 @@ class EventProviderTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         event_provider_list = EventProvider.list_available_plugins()
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertIn((mock.ANY, test_implementation_name), event_provider_list)
 
 
@@ -59,7 +59,7 @@ class UtilityFunctionTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         fqc = fully_qualified_classname(a_class)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(fqc, ".".join([a_class.__module__, a_class.__qualname__]))
 
     def test_fully_qualified_classname_instance(self):
@@ -73,7 +73,7 @@ class UtilityFunctionTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         fqc = fully_qualified_classname(an_instance)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(
             fqc,
             ".".join(

--- a/tests/models/test_event.py
+++ b/tests/models/test_event.py
@@ -7,16 +7,35 @@ import datetime
 from unittest import mock, skip  # noqa: F401
 
 # Django imports
+from django.contrib.auth.models import User
 from django.test import override_settings, tag  # noqa: F401
 
 # app imports
-from calingen.models.event import Event
+from calingen.models.event import Event, EventQuerySet
 
 # local imports
-from ..util.testcases import CalingenTestCase
+from ..util.testcases import CalingenORMTestCase, CalingenTestCase
 
 
-@tag("models", "event")
+@tag("models", "event", "EventQuerySet")
+class EventQuerySetTest(CalingenORMTestCase):
+    def test_filter_by_user(self):
+        # Arrange (set up test environment)
+        alice = User.objects.get(pk=2)  # Alice!
+        alice_events = Event.objects.filter(profile__owner=alice).all()
+        bob = User.objects.get(pk=2)  # Alice!
+        bob_events = Event.objects.filter(profile__owner=bob).all()
+
+        # Act (actually perform what has to be done)
+        test_alice_events = EventQuerySet(Event).filter_by_user(alice)
+        test_bob_events = EventQuerySet(Event).filter_by_user(bob)
+
+        # Assert (verify the results)
+        self.assertQuerysetEqual(alice_events, test_alice_events, ordered=False)
+        self.assertQuerysetEqual(bob_events, test_bob_events, ordered=False)
+
+
+@tag("models", "event", "Event")
 class EventTest(CalingenTestCase):
     @mock.patch("calingen.models.event.CalenderEntry")
     @mock.patch("calingen.models.event.CalenderEntryList")

--- a/tests/models/test_event.py
+++ b/tests/models/test_event.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django.test import override_settings, tag  # noqa: F401
 
 # app imports
-from calingen.models.event import Event, EventQuerySet
+from calingen.models.event import Event, EventModelException, EventQuerySet
 
 # local imports
 from ..util.testcases import CalingenORMTestCase, CalingenTestCase
@@ -33,6 +33,34 @@ class EventQuerySetTest(CalingenORMTestCase):
         # Assert (verify the results)
         self.assertQuerysetEqual(alice_events, test_alice_events, ordered=False)
         self.assertQuerysetEqual(bob_events, test_bob_events, ordered=False)
+
+
+@tag("models", "event", "EventManager")
+class EventManagerTest(CalingenORMTestCase):
+    def test_get_user_events_qs(self):
+        # Arrange (set up test environment)
+        alice = User.objects.get(pk=2)  # Alice!
+        alice_events = Event.objects.filter(profile__owner=alice).all()
+        bob = User.objects.get(pk=2)  # Alice!
+        bob_events = Event.objects.filter(profile__owner=bob).all()
+
+        # Act (actually perform what has to be done)
+        test_alice_events = Event.calingen_manager.get_user_events_qs(user=alice)
+        test_bob_events = Event.calingen_manager.get_user_events_qs(user=bob)
+
+        # Assert (verify the results)
+        self.assertQuerysetEqual(alice_events, test_alice_events, ordered=False)
+        self.assertQuerysetEqual(bob_events, test_bob_events, ordered=False)
+
+    def test_get_user_events_qs_exception(self):
+        # Arrange (set up test environment)
+
+        # Act (actually perform what has to be done)
+        # Assert (verify the results)
+        with self.assertRaises(EventModelException):
+            test_alice_events = (  # noqa: F841
+                Event.calingen_manager.get_user_events_qs()
+            )
 
 
 @tag("models", "event", "Event")

--- a/tests/models/test_event.py
+++ b/tests/models/test_event.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-"""Provide tests for calingen.models.profile."""
+"""Provide tests for calingen.models.event."""
 
 # Python imports
 import datetime
@@ -31,7 +31,7 @@ class EventTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = event.resolve(year=2020)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         mock_ce.assert_called_with("foo", "bar", datetime.date(2020, 12, 3), mock.ANY)
         self.assertIsInstance(return_value, mock.MagicMock)
 
@@ -52,6 +52,6 @@ class EventTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = event.resolve()
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         mock_ce.assert_called_with("foo", "bar", mock_datetime.date(), mock.ANY)
         self.assertIsInstance(return_value, mock.MagicMock)

--- a/tests/models/test_event.py
+++ b/tests/models/test_event.py
@@ -31,8 +31,10 @@ class EventQuerySetTest(CalingenORMTestCase):
         test_bob_events = EventQuerySet(Event).filter_by_user(bob)
 
         # Assert (verify the results)
-        self.assertQuerysetEqual(alice_events, test_alice_events, ordered=False)
-        self.assertQuerysetEqual(bob_events, test_bob_events, ordered=False)
+        self.assertQuerysetEqual(
+            alice_events, map(repr, test_alice_events), ordered=False
+        )
+        self.assertQuerysetEqual(bob_events, map(repr, test_bob_events), ordered=False)
 
 
 @tag("models", "event", "EventManager")
@@ -49,8 +51,10 @@ class EventManagerTest(CalingenORMTestCase):
         test_bob_events = Event.calingen_manager.get_user_events_qs(user=bob)
 
         # Assert (verify the results)
-        self.assertQuerysetEqual(alice_events, test_alice_events, ordered=False)
-        self.assertQuerysetEqual(bob_events, test_bob_events, ordered=False)
+        self.assertQuerysetEqual(
+            alice_events, map(repr, test_alice_events), ordered=False
+        )
+        self.assertQuerysetEqual(bob_events, map(repr, test_bob_events), ordered=False)
 
     def test_get_user_events_qs_exception(self):
         # Arrange (set up test environment)

--- a/tests/models/test_event.py
+++ b/tests/models/test_event.py
@@ -62,6 +62,17 @@ class EventManagerTest(CalingenORMTestCase):
                 Event.calingen_manager.get_user_events_qs()
             )
 
+    def test_summary(self):
+        # Arrange (set up test environment)
+        alice = User.objects.get(pk=2)  # Alice!
+        alice_events = Event.objects.filter(profile__owner=alice).count()
+
+        # Act (actually perform what has to be done)
+        test_alice_events = Event.calingen_manager.summary(user=alice)
+
+        # Assert (verify the results)
+        self.assertEqual(alice_events, test_alice_events)
+
 
 @tag("models", "event", "Event")
 class EventTest(CalingenTestCase):

--- a/tests/models/test_event.py
+++ b/tests/models/test_event.py
@@ -73,6 +73,22 @@ class EventManagerTest(CalingenORMTestCase):
         # Assert (verify the results)
         self.assertEqual(alice_events, test_alice_events)
 
+    @mock.patch("calingen.models.event.CalenderEntryList")
+    def test_get_calender_entry_list(self, mock_calenderentrylist):
+        # Arrange (set up test environment)
+        mock_merge = mock.MagicMock()
+        mock_calenderentrylist.return_value.merge = mock_merge
+        alice = User.objects.get(pk=2)  # Alice!
+        alice_events = Event.objects.filter(profile__owner=alice).count()
+
+        # Act (actually perform what has to be done)
+        test_alice_events = (  # noqa: F841
+            Event.calingen_manager.get_calender_entry_list(user=alice)
+        )
+
+        # Assert (verify the results)
+        self.assertEqual(mock_merge.call_count, alice_events)
+
 
 @tag("models", "event", "Event")
 class EventTest(CalingenTestCase):

--- a/tests/models/test_profile.py
+++ b/tests/models/test_profile.py
@@ -34,7 +34,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.event_provider
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value["active"], [])
         self.assertEqual(return_value["unavailable"], [])
         self.assertEqual(return_value["newly_unavailable"], [])
@@ -55,7 +55,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.event_provider
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value["active"], ["foo.bar"])
         self.assertEqual(return_value["unavailable"], [])
         self.assertEqual(return_value["newly_unavailable"], [])
@@ -78,7 +78,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.event_provider
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value["active"], [])
         self.assertEqual(return_value["unavailable"], ["foo.bar.buhu"])
         self.assertEqual(return_value["newly_unavailable"], [])
@@ -99,7 +99,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.event_provider
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value["active"], ["foo.bar", "foo.baz"])
         self.assertEqual(return_value["unavailable"], [])
         self.assertEqual(return_value["newly_unavailable"], [])
@@ -120,7 +120,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.event_provider
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value["active"], [])
         self.assertEqual(return_value["unavailable"], ["foo.bar.buhu"])
         self.assertEqual(return_value["newly_unavailable"], ["foo.bar.buhu"])
@@ -142,7 +142,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.resolve(year=2020)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         mock_cel.assert_called_once()
         mock_import_string.assert_called_once_with(test_active_provider)
         mock_cel.return_value.merge.assert_called_once()
@@ -167,7 +167,7 @@ class ProfileTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = profile.resolve()
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         mock_cel.assert_called_once()
         mock_import_string.assert_called_once_with(test_active_provider)
         mock_cel.return_value.merge.assert_called_once()

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -24,7 +24,7 @@ class CalingenChecksTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = check_config_value_event_provider_notification(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, [])
 
     @tag("config", "event_provider")
@@ -35,7 +35,7 @@ class CalingenChecksTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = check_config_value_event_provider_notification(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, [])
 
     @tag("config", "event_provider")
@@ -46,7 +46,7 @@ class CalingenChecksTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = check_config_value_event_provider_notification(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(return_value, [])
 
     @tag("config", "event_provider")
@@ -57,7 +57,7 @@ class CalingenChecksTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = check_config_value_event_provider_notification(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertNotEqual(return_value, [])
         self.assertEqual(len(return_value), 1)
 
@@ -69,7 +69,7 @@ class CalingenChecksTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = check_config_value_event_provider_notification(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertNotEqual(return_value, [])
         self.assertEqual(len(return_value), 1)
 
@@ -81,6 +81,6 @@ class CalingenChecksTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         return_value = check_config_value_event_provider_notification(None)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertNotEqual(return_value, [])
         self.assertEqual(len(return_value), 1)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-"""Provide tests for calingen.models.profile."""
+"""Provide tests for calingen.checks."""
 
 # Python imports
 from unittest import mock, skip  # noqa: F401

--- a/tests/util/fixtures/test_data.json
+++ b/tests/util/fixtures/test_data.json
@@ -1,0 +1,138 @@
+[
+{
+  "model": "auth.user",
+  "pk": 2,
+  "fields": {
+    "password": "pbkdf2_sha256$260000$eM5nGgGx25vhOAZ2uRkji7$KTwUMK2fP46go0Ap2vqN+ZUAMePlnZ7ksVmOwyJ/QeA=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "Alice",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-06T14:55:56.272",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "pk": 3,
+  "fields": {
+    "password": "pbkdf2_sha256$260000$zZNLLiz2C1WfnVNzUAGmAK$uEbWDXHG7+RcD0OKnS31HxYsuIwTWKAlXsShf8es1MQ=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "Bob",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-06T14:56:04.309",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "pk": 4,
+  "fields": {
+    "password": "pbkdf2_sha256$260000$YDYY2xVWkkVRQMPzEScyfd$F3m2J6tCcogUmfBsgTkVQ/IReuGU/AlUHcXcmSwaNvE=",
+    "last_login": null,
+    "is_superuser": true,
+    "username": "Charly",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": true,
+    "is_active": true,
+    "date_joined": "2021-12-06T14:56:17",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "pk": 5,
+  "fields": {
+    "password": "pbkdf2_sha256$260000$n8AScTqPGhPIAV9zzVZGEr$RriivK2/ibcnLGbkIrN8W3Rv/Bczj5V64om5tCmJjIk=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "Egon",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-06T16:12:19.053",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "calingen.profile",
+  "pk": 1,
+  "fields": {
+    "_event_provider": {},
+    "owner": 2
+  }
+},
+{
+  "model": "calingen.profile",
+  "pk": 2,
+  "fields": {
+    "_event_provider": {},
+    "owner": 3
+  }
+},
+{
+  "model": "calingen.profile",
+  "pk": 3,
+  "fields": {
+    "_event_provider": {},
+    "owner": 4
+  }
+},
+{
+  "model": "calingen.event",
+  "pk": 1,
+  "fields": {
+    "profile": 1,
+    "start": "2020-12-06T06:00:00",
+    "title": "Go and grab Candy!",
+    "category": "ANNUAL_ANNIVERSARY"
+  }
+},
+{
+  "model": "calingen.event",
+  "pk": 2,
+  "fields": {
+    "profile": 1,
+    "start": "2020-11-30T06:00:00",
+    "title": "Whatever is going on here",
+    "category": "ANNUAL_ANNIVERSARY"
+  }
+},
+{
+  "model": "calingen.event",
+  "pk": 3,
+  "fields": {
+    "profile": 1,
+    "start": "2022-01-01T06:00:00",
+    "title": "Finally a new year",
+    "category": "ANNUAL_ANNIVERSARY"
+  }
+},
+{
+  "model": "calingen.event",
+  "pk": 4,
+  "fields": {
+    "profile": 2,
+    "start": "1985-10-26T14:00:00",
+    "title": "Back to the Future",
+    "category": "ANNUAL_ANNIVERSARY"
+  }
+}
+]

--- a/tests/util/settings_test.py
+++ b/tests/util/settings_test.py
@@ -56,7 +56,7 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
-            os.path.join(TEST_ROOT, "utils", "templates"),
+            os.path.join(TEST_ROOT, "util", "templates"),
         ],
         "APP_DIRS": True,
         "OPTIONS": {

--- a/tests/util/templates/registration/login.html
+++ b/tests/util/templates/registration/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Login | development server</title>
+  </head>
+  <body>
+    <h1>Login</h1>
+    <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+    </form>
+  </body>
+</html>

--- a/tests/util/testcases.py
+++ b/tests/util/testcases.py
@@ -4,6 +4,7 @@
 
 # Django imports
 from django.test import SimpleTestCase, TestCase
+from django.test.testcases import TransactionTestCase
 
 
 # Add documentation if there is acutally code!
@@ -38,4 +39,8 @@ class CalingenORMTestCase(TestCase):  # noqa: D101
             --output tests/util/fixtures/test_data.json
     """
 
+    fixtures = ["tests/util/fixtures/test_data.json"]
+
+
+class CalingenORMTransactionTestCase(TransactionTestCase):  # noqa: D101
     fixtures = ["tests/util/fixtures/test_data.json"]

--- a/tests/util/testcases.py
+++ b/tests/util/testcases.py
@@ -3,9 +3,39 @@
 """Provides app-specific test classes."""
 
 # Django imports
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 
 # Add documentation if there is acutally code!
-class CalingenTestCase(TestCase):  # noqa: D101
+class CalingenTestCase(SimpleTestCase):  # noqa: D101
     pass
+
+
+class CalingenORMTestCase(TestCase):  # noqa: D101
+    """Support testing with fixture data.
+
+    What is included in this test fixture?
+    ======================================
+    - 4 user instances (django.contrib.auth.User)
+        - Alice, Bob, Charly (superuser), Egon
+        - all passwords: "foobar"
+    - 3 Profile instances (calingen.models.profile.Profile)
+        - Alice, Bob, Charly
+    - 4 Events (calingen.models.event.Event)
+        - Alice (3 Events)
+        - Bob (1 Event)
+
+    Command to dump the data
+    ------------------------
+    > tox -q -e django -- \
+        dumpdata \
+            --all \
+            --indent 2 \
+            --exclude admin.logentry \
+            --exclude auth.permission \
+            --exclude sessions.session \
+            --exclude contenttypes.contenttype \
+            --output tests/util/fixtures/test_data.json
+    """
+
+    fixtures = ["tests/util/fixtures/test_data.json"]

--- a/tests/views/test_base.py
+++ b/tests/views/test_base.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-"""Provide tests for calingen.models.profile."""
+"""Provide tests for calingen.views.base."""
 
 # Python imports
 from unittest import mock, skip  # noqa: F401
@@ -20,20 +20,26 @@ from ..util.testcases import CalingenORMTestCase
 @tag("views", "base", "homepage")
 class CalingenHomepageTest(CalingenORMTestCase):
     def test_profile_not_available(self):
+        # Arrange (set up test environment)
         self.user = User.objects.get(pk=5)
         self.client = Client()
         self.client.force_login(self.user)
 
+        # Act (actually perform what has to be done)
         response = self.client.get(reverse("homepage"), follow=True)
 
+        # Assert (verify the results)
         self.assertRedirects(response, reverse("profile-add"))
 
     def test_profile_available(self):
+        # Arrange (set up test environment)
         self.user = User.objects.get(pk=2)
         self.profile = Profile.objects.get(owner=self.user)
         self.client = Client()
         self.client.force_login(self.user)
 
+        # Act (actually perform what has to be done)
         response = self.client.get(reverse("homepage"), follow=True)
 
+        # Assert (verify the results)
         self.assertRedirects(response, reverse("profile", args=[self.profile.id]))

--- a/tests/views/test_base.py
+++ b/tests/views/test_base.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+
+"""Provide tests for calingen.models.profile."""
+
+# Python imports
+from unittest import mock, skip  # noqa: F401
+
+# Django imports
+from django.test import RequestFactory, override_settings, tag  # noqa: F401
+
+# app imports
+from calingen.views.base import homepage
+
+# local imports
+from ..util.testcases import CalingenTestCase
+
+
+@tag("views", "base", "homepage")
+class CalingenHomepageTest(CalingenTestCase):
+
+    factory = RequestFactory()
+
+    @mock.patch("calingen.views.base.redirect")
+    @mock.patch("calingen.views.base.Profile")
+    def test_profile_not_available(self, mock_profile, mock_redirect):
+        # Arrange (set up test environment)
+        mock_profile_manager = mock.PropertyMock()
+        mock_profile_manager.get_profile.return_value = None
+        mock_profile.calingen_manager = mock_profile_manager
+        request = self.factory.get("/rand")
+        request.user = "foo"
+        view = homepage.__wrapped__
+
+        # Act (actually perform what has to be done)
+        response = view(request)  # noqa: F841
+
+        # Assert (verify the results)
+        self.assertTrue(mock_profile_manager.get_profile.called)
+        self.assertTrue(mock_redirect.called)
+        mock_redirect.assert_called_with("profile-add")
+
+    @mock.patch("calingen.views.base.redirect")
+    @mock.patch("calingen.views.base.Profile")
+    def test_profile_available(self, mock_profile, mock_redirect):
+        # Arrange (set up test environment)
+        mock_profile_manager = mock.PropertyMock()
+        mock_profile_manager.get_profile.return_value = mock.Mock()
+        mock_profile.calingen_manager = mock_profile_manager
+        request = self.factory.get("/rand")
+        request.user = "foo"
+        view = homepage.__wrapped__
+
+        # Act (actually perform what has to be done)
+        response = view(request)  # noqa: F841
+
+        # Assert (verify the results)
+        self.assertTrue(mock_profile_manager.get_profile.called)
+        self.assertTrue(mock_redirect.called)
+        mock_redirect.assert_called_with(
+            "profile", profile_id=mock_profile_manager.get_profile.return_value.id
+        )

--- a/tests/views/test_base.py
+++ b/tests/views/test_base.py
@@ -29,6 +29,7 @@ class CalingenHomepageTest(CalingenTestCase):
         mock_profile.calingen_manager = mock_profile_manager
         request = self.factory.get("/rand")
         request.user = "foo"
+        # see: https://pythonin1minute.com/how-to-test-decorators-in-python/
         view = homepage.__wrapped__
 
         # Act (actually perform what has to be done)
@@ -48,6 +49,7 @@ class CalingenHomepageTest(CalingenTestCase):
         mock_profile.calingen_manager = mock_profile_manager
         request = self.factory.get("/rand")
         request.user = "foo"
+        # see: https://pythonin1minute.com/how-to-test-decorators-in-python/
         view = homepage.__wrapped__
 
         # Act (actually perform what has to be done)

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+
+"""Provide tests for calingen.models.profile."""
+
+# Python imports
+from unittest import mock, skip  # noqa: F401
+
+# Django imports
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings, tag  # noqa: F401
+from django.views.generic import View
+
+# app imports
+from calingen.views.mixins import CalingenRestrictToUserMixin
+
+# local imports
+from ..util.testcases import CalingenTestCase
+
+
+class QuerySetView(View):
+    """Just a dummy CBV to test the app's mixins with database access."""
+
+    def get(self, request, *args, **kwargs):
+        objects = self.get_queryset()  # noqa: F841
+
+        return HttpResponse()
+
+
+class RestrictToUserMixinAppliedView(CalingenRestrictToUserMixin, QuerySetView):
+    """Combines the app's mixin with a dummy CBV."""
+
+    model = None
+
+
+@tag("views", "mixins")
+class CalingenRestrictToUserMixinTest(CalingenTestCase):
+
+    factory = RequestFactory()
+
+    def test_mixin_raises_error_on_missing_model(self):
+        """The attribute `model` is required."""
+        request = self.factory.get("/rand")
+        request.user = "foo"
+        view = RestrictToUserMixinAppliedView.as_view()
+
+        with self.assertRaises(ImproperlyConfigured):
+            response = view(request)  # noqa: F841
+
+    def test_mixin_uses_stockings_manager_method(self):
+        """The app-specific manager is correctly called."""
+        cbv = RestrictToUserMixinAppliedView
+        cbv.model = mock.MagicMock()
+
+        request = self.factory.get("/rand")
+        request.user = "foo"
+        view = cbv.as_view()
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertTrue(
+            cbv.model.calingen_manager.get_queryset.return_value.filter_by_user.called
+        )
+        cbv.model.calingen_manager.get_queryset.return_value.filter_by_user.assert_called_with(
+            request.user
+        )

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -44,8 +44,8 @@ class UserProfileIDMixinAppliedView(ProfileIDMixin, ContextMixin, TestTemplateVi
     pass
 
 
-@tag("views", "mixins", "CalingenRestrictToUserMixin")
-class CalingenRestrictToUserMixinTest(CalingenTestCase):
+@tag("views", "mixins", "RestrictToUserMixin")
+class RestrictToUserMixinTest(CalingenTestCase):
 
     factory = RequestFactory()
 
@@ -83,8 +83,8 @@ class CalingenRestrictToUserMixinTest(CalingenTestCase):
         )
 
 
-@tag("views", "mixins", "CalingenUserProfileIDMixin")
-class CalingenUserProfileIDMixinTest(CalingenTestCase):
+@tag("views", "mixins", "ProfileIDMixin")
+class ProfileIDMixinTest(CalingenTestCase):
 
     factory = RequestFactory()
 

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -10,9 +10,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings, tag  # noqa: F401
 from django.views.generic import View
+from django.views.generic.base import ContextMixin
 
 # app imports
-from calingen.views.mixins import CalingenRestrictToUserMixin
+from calingen.views.mixins import (
+    CalingenRestrictToUserMixin,
+    CalingenUserProfileIDMixin,
+)
 
 # local imports
 from ..util.testcases import CalingenTestCase
@@ -27,42 +31,81 @@ class QuerySetView(View):
         return HttpResponse()
 
 
+class TestTemplateView(View):
+    def get(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)  # noqa: F841
+        return HttpResponse()
+
+
 class RestrictToUserMixinAppliedView(CalingenRestrictToUserMixin, QuerySetView):
     """Combines the app's mixin with a dummy CBV."""
 
     model = None
 
 
-@tag("views", "mixins")
+class UserProfileIDMixinAppliedView(
+    CalingenUserProfileIDMixin, ContextMixin, TestTemplateView
+):
+    pass
+
+
+@tag("views", "mixins", "CalingenRestrictToUserMixin")
 class CalingenRestrictToUserMixinTest(CalingenTestCase):
 
     factory = RequestFactory()
 
     def test_mixin_raises_error_on_missing_model(self):
         """The attribute `model` is required."""
+        # Arrange (set up test environment)
         request = self.factory.get("/rand")
         request.user = "foo"
         view = RestrictToUserMixinAppliedView.as_view()
 
+        # Act (actually perform what has to be done)
+        # Assert (verify the results))
         with self.assertRaises(ImproperlyConfigured):
             response = view(request)  # noqa: F841
 
     def test_mixin_uses_stockings_manager_method(self):
         """The app-specific manager is correctly called."""
+        # Arrange (set up test environment)
         cbv = RestrictToUserMixinAppliedView
         cbv.model = mock.MagicMock()
-
         request = self.factory.get("/rand")
         request.user = "foo"
         view = cbv.as_view()
 
+        # Act (actually perform what has to be done)
         response = view(request)
 
+        # Assert (verify the results))
         self.assertEqual(response.status_code, 200)
-
         self.assertTrue(
             cbv.model.calingen_manager.get_queryset.return_value.filter_by_user.called
         )
         cbv.model.calingen_manager.get_queryset.return_value.filter_by_user.assert_called_with(
             request.user
         )
+
+
+@tag("views", "mixins", "CalingenUserProfileIDMixin")
+class CalingenUserProfileIDMixinTest(CalingenTestCase):
+
+    factory = RequestFactory()
+
+    @mock.patch("calingen.views.mixins.Profile")
+    def test_mixin_tries_to_determine_user_profile(self, mock_profile):
+        # Arrange (set up test environment)
+        mock_profile_manager = mock.PropertyMock()
+        mock_profile.calingen_manager = mock_profile_manager
+        cbv = UserProfileIDMixinAppliedView
+        request = self.factory.get("/rand")
+        request.user = "foo"
+        view = cbv.as_view()
+
+        # Act (actually perform what has to be done)
+        response = view(request)
+
+        # Assert (verify the results))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(mock_profile_manager.get_profile.called)

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -13,10 +13,7 @@ from django.views.generic import View
 from django.views.generic.base import ContextMixin
 
 # app imports
-from calingen.views.mixins import (
-    CalingenRestrictToUserMixin,
-    CalingenUserProfileIDMixin,
-)
+from calingen.views.mixins import CalingenRestrictToUserMixin, ProfileIDMixin
 
 # local imports
 from ..util.testcases import CalingenTestCase
@@ -43,9 +40,7 @@ class RestrictToUserMixinAppliedView(CalingenRestrictToUserMixin, QuerySetView):
     model = None
 
 
-class UserProfileIDMixinAppliedView(
-    CalingenUserProfileIDMixin, ContextMixin, TestTemplateView
-):
+class UserProfileIDMixinAppliedView(ProfileIDMixin, ContextMixin, TestTemplateView):
     pass
 
 

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -13,7 +13,7 @@ from django.views.generic import View
 from django.views.generic.base import ContextMixin
 
 # app imports
-from calingen.views.mixins import CalingenRestrictToUserMixin, ProfileIDMixin
+from calingen.views.mixins import ProfileIDMixin, RestrictToUserMixin
 
 # local imports
 from ..util.testcases import CalingenTestCase
@@ -34,7 +34,7 @@ class TestTemplateView(View):
         return HttpResponse()
 
 
-class RestrictToUserMixinAppliedView(CalingenRestrictToUserMixin, QuerySetView):
+class RestrictToUserMixinAppliedView(RestrictToUserMixin, QuerySetView):
     """Combines the app's mixin with a dummy CBV."""
 
     model = None

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-"""Provide tests for calingen.models.profile."""
+"""Provide tests for calingen.views.mixins."""
 
 # Python imports
 from unittest import mock, skip  # noqa: F401

--- a/tests/views/test_mixins.py
+++ b/tests/views/test_mixins.py
@@ -67,7 +67,7 @@ class RestrictToUserMixinTest(CalingenTestCase):
         view = RestrictToUserMixinAppliedView.as_view()
 
         # Act (actually perform what has to be done)
-        # Assert (verify the results))
+        # Assert (verify the results)
         with self.assertRaises(ImproperlyConfigured):
             response = view(request)  # noqa: F841
 
@@ -83,7 +83,7 @@ class RestrictToUserMixinTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         response = view(request)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(
             cbv.model.calingen_manager.get_queryset.return_value.filter_by_user.called
@@ -111,7 +111,7 @@ class ProfileIDMixinTest(CalingenTestCase):
         # Act (actually perform what has to be done)
         response = view(request)
 
-        # Assert (verify the results))
+        # Assert (verify the results)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(mock_profile_manager.get_profile.called)
 

--- a/tests/views/test_profile.py
+++ b/tests/views/test_profile.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+
+"""Provide tests for calingen.views.profile."""
+
+# Python imports
+from unittest import mock, skip  # noqa: F401
+
+# Django imports
+from django.contrib.auth.models import User
+from django.test import Client, override_settings, tag  # noqa: F401
+from django.urls import reverse
+
+# local imports
+from ..util.testcases import CalingenORMTransactionTestCase
+
+
+@tag("views", "profile", "ProfileCreateView")
+class ProfileCreateViewTest(CalingenORMTransactionTestCase):
+    # This is based on Django's TransactionTestCase to make
+    # test_profile_already_exists work!
+    # Problem is the method of resetting the database to a known state after
+    # the tests. As the subject under test relies on the database's
+    # IntegrityError, the default Django TestCase does not work.
+
+    def test_profile_does_not_exist(self):
+        # Arrange (set up test environment)
+        self.user = User.objects.get(pk=5)
+        self.client = Client()
+        self.client.force_login(self.user)
+        # Alice=1, Bob=2, Charly=3...
+        expected_profile_id = 4
+
+        # Act (actually perform what has to be done)
+        response = self.client.post(reverse("profile-add"), follow=True)
+
+        # Assert (verify the results)
+        self.assertRedirects(
+            response, reverse("profile", kwargs={"profile_id": expected_profile_id})
+        )
+
+    def test_profile_already_exists(self):
+        # Arrange (set up test environment)
+        self.user = User.objects.get(pk=2)  # Alice!
+        self.client = Client()
+        self.client.force_login(self.user)
+        # Alice=1, Bob=2, Charly=3...
+        expected_profile_id = 1
+
+        # Act (actually perform what has to be done)
+        response = self.client.post(reverse("profile-add"), follow=True)
+
+        # Assert (verify the results)
+        self.assertRedirects(
+            response, reverse("profile", kwargs={"profile_id": expected_profile_id})
+        )


### PR DESCRIPTION
**Abstract**
This PR should finish the web views for the initial release. It will not be polished, but it will work.

**Steps**
- [x] Close web view related issues
  - [x] #18
  - [x] #19 
- [x] provide test suite for ``views`` package (around 70% coverage as of [512e36f](https://github.com/Mischback/django-calingen/commit/512e36fc082b34f5d530f05ba28bfe0eaf38f442)!)
- [x] [chore] ``tests.util.urls_dev`` already contains the ``urls`` of ``django.contrib.auth``; just provide (basic) templates for them to make login work during development
  - [x] backport this to ``backport/setup``