### PR TITLE
Refactor: EventProvider

### DIFF
--- a/calingen/apps.py
+++ b/calingen/apps.py
@@ -3,7 +3,6 @@
 """Application configuration as required by Django."""
 
 # Python imports
-import importlib
 import logging
 
 # Django imports
@@ -41,12 +40,6 @@ class CalingenConfig(AppConfig):
         - inject app-specific settings into the project's ``settings`` module,
           if they are not already specified (see
           :mod:`calingen.settings` for details);
-        - import implementations of
-          :class:`calingen.interfaces.plugin_api.EventProvider` to make them
-          available (as specified by
-          :attr:`calingen.settings.CALINGEN_EXTERNAL_EVENT_PROVIDER`)
-
-          **THIS MAY BE SUBJECT TO CHANGE!** See :issue:`49`!
         """
         # delay app imports until now, to make sure everything else is ready
         # app imports
@@ -69,7 +62,3 @@ class CalingenConfig(AppConfig):
         register_check(check_config_value_compiler)
         register_check(check_config_value_event_provider_notification)
         register_check(check_session_enabled)
-
-        # load the external event providers
-        for provider in settings.CALINGEN_EXTERNAL_EVENT_PROVIDER:  # pragma: nocover
-            importlib.import_module(provider)  # pragma: nocover

--- a/calingen/contrib/providers/german_holidays/__init__.py
+++ b/calingen/contrib/providers/german_holidays/__init__.py
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: MIT
 
-"""Implementation of :class:`~calingen.interfaces.plugin_api.EventProvider` that provide German holidays, splitted by federate states."""
+"""Implementation of :class:`~calingen.interfaces.plugin_api.EventProvider` that provide German holidays, splitted by federate states.
+
+In fact, it is not only *one* implementation of
+:class:`~calingen.interfaces.plugin_api.EventProvider`, but 17.
+
+Notes
+-----
+The app-specific setting ``CALINGEN_PROVIDER_GERMAN_HOLIDAYS`` can be used to
+filter the actually provided event providers.
+"""
 
 
 default_app_config = (
@@ -11,12 +20,4 @@ default_app_config = (
 Consider this *legacy code*. See
 :djangoapi:`Django's documentation<applications/#configuring-applications>` for
 details.
-
-Notes
------
-This application does provide the holidays for Germany, splitted by Federal
-States.
-
-In fact, it is not only *one* implementation of
-:class:`~calingen.interfaces.plugin_api.EventProvider`, but 17.
 """

--- a/calingen/contrib/providers/german_holidays/__init__.py
+++ b/calingen/contrib/providers/german_holidays/__init__.py
@@ -4,11 +4,6 @@
 
 In fact, it is not only *one* implementation of
 :class:`~calingen.interfaces.plugin_api.EventProvider`, but 17.
-
-Notes
------
-The app-specific setting ``CALINGEN_PROVIDER_GERMAN_HOLIDAYS`` can be used to
-filter the actually provided event providers.
 """
 
 

--- a/calingen/contrib/providers/german_holidays/__init__.py
+++ b/calingen/contrib/providers/german_holidays/__init__.py
@@ -2,23 +2,21 @@
 
 """Implementation of :class:`~calingen.interfaces.plugin_api.EventProvider` that provide German holidays, splitted by federate states."""
 
-# local imports
-from .provider import (  # noqa: F401
-    BadenWuerttemberg,
-    Bayern,
-    Berlin,
-    Brandenburg,
-    Bremen,
-    GermanyFederal,
-    Hamburg,
-    Hessen,
-    MecklenburgVorpommern,
-    Niedersachsen,
-    NordrheinWestphalen,
-    RheinlandPfalz,
-    Saarland,
-    Sachsen,
-    SachsenAnhalt,
-    SchleswigHolstein,
-    Thueringen,
+
+default_app_config = (
+    "calingen.contrib.providers.german_holidays.apps.CalingenProviderGermanHolidays"
 )
+"""The path to the app's default configuration class.
+
+Consider this *legacy code*. See
+:djangoapi:`Django's documentation<applications/#configuring-applications>` for
+details.
+
+Notes
+-----
+This application does provide the holidays for Germany, splitted by Federal
+States.
+
+In fact, it is not only *one* implementation of
+:class:`~calingen.interfaces.plugin_api.EventProvider`, but 17.
+"""

--- a/calingen/contrib/providers/german_holidays/apps.py
+++ b/calingen/contrib/providers/german_holidays/apps.py
@@ -4,6 +4,10 @@
 
 # Django imports
 from django.apps import AppConfig
+from django.conf import settings
+
+APP_CONFIG_NAME = "CALINGEN_PROVIDER_GERMAN_HOLIDAYS"
+"""The name of the app-specific configuration option."""
 
 
 class CalingenProviderGermanHolidays(AppConfig):
@@ -16,3 +20,95 @@ class CalingenProviderGermanHolidays(AppConfig):
 
     name = "calingen.contrib.providers.german_holidays"
     verbose_name = "CalInGen Provider: German Holidays"
+
+    def ready(self):
+        """Apply app-specific stuff.
+
+        Notes
+        -----
+        This method is executed when the application is (completely) loaded.
+
+        It performs the following actions:
+
+        - it checks this app's app-specific setting and performs an import of
+          the required implementations of
+          :class:`~calingen.interfaces.plugin_api.EventProvider`, registering
+          them with the plugin mount point and thus, making them available in
+          **django-calingen**.
+        """
+        # Provide a default value for CALINGEN_PROVIDER_GERMAN_HOLIDAYS, if not
+        # present in the project's settings module
+        if not hasattr(settings, APP_CONFIG_NAME):
+            setattr(settings, APP_CONFIG_NAME, "all")
+
+        app_settings = getattr(settings, APP_CONFIG_NAME)
+        if app_settings == "all":
+            # local imports
+            from .provider import (  # noqa: F401
+                BadenWuerttemberg,
+                Bayern,
+                Berlin,
+                Brandenburg,
+                Bremen,
+                GermanyFederal,
+                Hamburg,
+                Hessen,
+                MecklenburgVorpommern,
+                Niedersachsen,
+                NordrheinWestphalen,
+                RheinlandPfalz,
+                Saarland,
+                Sachsen,
+                SachsenAnhalt,
+                SchleswigHolstein,
+                Thueringen,
+            )
+        else:
+            if "BadenWuerttember" in app_settings:
+                # local imports
+                from .provider import BadenWuerttemberg  # noqa: F401
+            if "Bayer" in app_settings:
+                # local imports
+                from .provider import Bayern  # noqa: F401
+            if "Berlin" in app_settings:
+                # local imports
+                from .provider import Berlin  # noqa: F401
+            if "Brandenburg" in app_settings:
+                # local imports
+                from .provider import Brandenburg  # noqa: F401
+            if "Bremen" in app_settings:
+                # local imports
+                from .provider import Bremen  # noqa: F401
+            if "Hamburg" in app_settings:
+                # local imports
+                from .provider import Hamburg  # noqa: F401
+            if "Hessen" in app_settings:
+                # local imports
+                from .provider import Hessen  # noqa: F401
+            if "MecklenburgVorpommern" in app_settings:
+                # local imports
+                from .provider import MecklenburgVorpommern  # noqa: F401
+            if "Niedersachsen" in app_settings:
+                # local imports
+                from .provider import Niedersachsen  # noqa: F401
+            if "NordrheinWestphalen" in app_settings:
+                # local imports
+                from .provider import NordrheinWestphalen  # noqa: F401
+            if "RheinlandPfalz" in app_settings:
+                # local imports
+                from .provider import RheinlandPfalz  # noqa: F401
+            if "Saarland" in app_settings:
+                # local imports
+                from .provider import Saarland  # noqa: F401
+            if "Sachsen" in app_settings:
+                # local imports
+                from .provider import Sachsen  # noqa: F401
+            if "SachsenAnhalt" in app_settings:
+                # local imports
+                from .provider import SachsenAnhalt  # noqa: F401
+            if "SchleswigHolstein" in app_settings:
+                # local imports
+                from .provider import SchleswigHolstein  # noqa: F401
+            if "Thueringen" in app_settings:
+                # local imports
+                from .provider import Thueringen  # noqa: F401

--- a/calingen/contrib/providers/german_holidays/apps.py
+++ b/calingen/contrib/providers/german_holidays/apps.py
@@ -4,7 +4,6 @@
 
 # Django imports
 from django.apps import AppConfig
-from django.conf import settings
 
 APP_CONFIG_NAME = "CALINGEN_PROVIDER_GERMAN_HOLIDAYS"
 """The name of the app-specific configuration option."""
@@ -28,87 +27,27 @@ class CalingenProviderGermanHolidays(AppConfig):
         -----
         This method is executed when the application is (completely) loaded.
 
-        It performs the following actions:
-
-        - it checks this app's app-specific setting and performs an import of
-          the required implementations of
-          :class:`~calingen.interfaces.plugin_api.EventProvider`, registering
-          them with the plugin mount point and thus, making them available in
-          **django-calingen**.
+        It will import the actual implementations of
+        :class:`~calingen.interfaces.plugin_api.EventProvider`, making them
+        available in **django-calingen**.
         """
-        # Provide a default value for CALINGEN_PROVIDER_GERMAN_HOLIDAYS, if not
-        # present in the project's settings module
-        if not hasattr(settings, APP_CONFIG_NAME):
-            setattr(settings, APP_CONFIG_NAME, "all")
-
-        app_settings = getattr(settings, APP_CONFIG_NAME)
-        if app_settings == "all":
-            # local imports
-            from .provider import (  # noqa: F401
-                BadenWuerttemberg,
-                Bayern,
-                Berlin,
-                Brandenburg,
-                Bremen,
-                GermanyFederal,
-                Hamburg,
-                Hessen,
-                MecklenburgVorpommern,
-                Niedersachsen,
-                NordrheinWestphalen,
-                RheinlandPfalz,
-                Saarland,
-                Sachsen,
-                SachsenAnhalt,
-                SchleswigHolstein,
-                Thueringen,
-            )
-        else:
-            if "BadenWuerttember" in app_settings:
-                # local imports
-                from .provider import BadenWuerttemberg  # noqa: F401
-            if "Bayer" in app_settings:
-                # local imports
-                from .provider import Bayern  # noqa: F401
-            if "Berlin" in app_settings:
-                # local imports
-                from .provider import Berlin  # noqa: F401
-            if "Brandenburg" in app_settings:
-                # local imports
-                from .provider import Brandenburg  # noqa: F401
-            if "Bremen" in app_settings:
-                # local imports
-                from .provider import Bremen  # noqa: F401
-            if "Hamburg" in app_settings:
-                # local imports
-                from .provider import Hamburg  # noqa: F401
-            if "Hessen" in app_settings:
-                # local imports
-                from .provider import Hessen  # noqa: F401
-            if "MecklenburgVorpommern" in app_settings:
-                # local imports
-                from .provider import MecklenburgVorpommern  # noqa: F401
-            if "Niedersachsen" in app_settings:
-                # local imports
-                from .provider import Niedersachsen  # noqa: F401
-            if "NordrheinWestphalen" in app_settings:
-                # local imports
-                from .provider import NordrheinWestphalen  # noqa: F401
-            if "RheinlandPfalz" in app_settings:
-                # local imports
-                from .provider import RheinlandPfalz  # noqa: F401
-            if "Saarland" in app_settings:
-                # local imports
-                from .provider import Saarland  # noqa: F401
-            if "Sachsen" in app_settings:
-                # local imports
-                from .provider import Sachsen  # noqa: F401
-            if "SachsenAnhalt" in app_settings:
-                # local imports
-                from .provider import SachsenAnhalt  # noqa: F401
-            if "SchleswigHolstein" in app_settings:
-                # local imports
-                from .provider import SchleswigHolstein  # noqa: F401
-            if "Thueringen" in app_settings:
-                # local imports
-                from .provider import Thueringen  # noqa: F401
+        # local imports
+        from .provider import (  # noqa: F401
+            BadenWuerttemberg,
+            Bayern,
+            Berlin,
+            Brandenburg,
+            Bremen,
+            GermanyFederal,
+            Hamburg,
+            Hessen,
+            MecklenburgVorpommern,
+            Niedersachsen,
+            NordrheinWestphalen,
+            RheinlandPfalz,
+            Saarland,
+            Sachsen,
+            SachsenAnhalt,
+            SchleswigHolstein,
+            Thueringen,
+        )

--- a/calingen/contrib/providers/german_holidays/apps.py
+++ b/calingen/contrib/providers/german_holidays/apps.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+
+"""Provide the application configuration for Django."""
+
+# Django imports
+from django.apps import AppConfig
+
+
+class CalingenProviderGermanHolidays(AppConfig):
+    """Application-specific configuration class, as required by Django.
+
+    This sub-class of Django's `AppConfig` provides application-specific
+    information to be used in Django's application registry (see
+    :djangoapi:`applications/#configuring-applications`).
+    """
+
+    name = "calingen.contrib.providers.german_holidays"
+    verbose_name = "CalInGen Provider: German Holidays"

--- a/calingen/settings.py
+++ b/calingen/settings.py
@@ -62,16 +62,6 @@ This setting is evaluated in :class:`calingen.views.generation.CompilerView`.
 importable.
 """
 
-CALINGEN_EXTERNAL_EVENT_PROVIDER = []
-"""Determines the available event providers.
-
-**Default value:** ``[]``
-
-Notes
------
-Include dotted Python paths to event provider implementations as :py:obj`str`.
-"""
-
 CALINGEN_MISSING_EVENT_PROVIDER_NOTIFICATION = None
 """Determines, if the user should be notified about missing event providers.
 

--- a/docs/source/cookbook/setup_step_by_step.rst
+++ b/docs/source/cookbook/setup_step_by_step.rst
@@ -275,9 +275,15 @@ Besides the actual app |calingen|, it is required to set up
 *optionally* -
 :ref:`external events <calingen-cookbook-ingredients-eventprovider-label>`.
 
-.. warning::
-  TODO: When :issue:`49` is closed, provide an example listing of the recipe's
-  ``INSTALLED_APPS`` with one layout and one event provider included.
+The following listing shows an example of :setting:`INSTALLED_APPS` that does
+incorporate a *layout* aswell as an external *event provider*: ::
+
+  INSTALLED_APPS = [
+      ...
+      'calingen.contrib.layouts.simple_event_list',  # <- added!
+      'calingen.contrib.providers.german_holidays',  # <- added!
+  ]
+
 
 .. note::
   How :ref:`compilers <calingen-cookbook-ingredients-compilers-label>` can be
@@ -293,10 +299,6 @@ App-specific Settings
 |calingen| has some app-specific settings that may be adjusted using the
 project's ``settings`` module. A thorough description of these settings can be
 found in :mod:`calingen.settings`' documentation.
-
-.. warning::
-  :attr:`calingen.settings.CALINGEN_EXTERNAL_EVENT_PROVIDER` is not described
-  here, because this setting will be removed; see :issue:`49`.
 
 
 .. _calingen-cookbook-setup-step-by-step-compiler-mapping-label:

--- a/docs/source/includes/ingredients/eventprovider.rst.txt
+++ b/docs/source/includes/ingredients/eventprovider.rst.txt
@@ -4,6 +4,38 @@
 Event Provider
 **************
 
+|calingen| provides a *plugin interface* for the provision of events by
+plugins.
+
+Technically, *event providers* are provided as standalone Django applications
+that register themselves with |calingen| and are integrated into the general
+workflow of the app (see :ref:`calingen-user-doc-generate-inlays-label`),
+therefore they may be installed like any other application into the Django
+project: just add them to the project's settings module in
+:setting:`INSTALLED_APPS`.
+
+.. note::
+  Even more technically: Event providers are implementations of the app's
+  plugin mount point :class:`~calingen.interfaces.plugin_api.EventProvider`.
+  See :ref:`calingen-dev-doc-plugins-eventprovider-label` for details.
+
+*Event providers* are selectable by the user in his profile settings.
+
+
+Included Event Providers
+========================
+
+|calingen| ships with one *event provider* out of the box. It is included in
+:mod:`calingen.contrib.providers`.
+
 .. warning::
-  This is subject to change, see :issue:`49`. Documentation has to be updated
-  when :issue:`49` is closed.
+  While this provider is *available* when |calingen| is installed, it must be
+  *activated* manually by including it in :setting:`INSTALLED_APPS`.
+
+German Holidays
+  Provides the holidays of the Federal Republic of Germany, split by its
+  federal states.
+
+  .. note::
+    All federal states are included and will be selectable in the user's
+    profile.

--- a/tests/util/settings_dev.py
+++ b/tests/util/settings_dev.py
@@ -10,6 +10,7 @@ INSTALLED_APPS += [
     "calingen.contrib.layouts.simple_event_list",
     "calingen.contrib.layouts.year_by_week",
     "calingen.contrib.layouts.lineatur",
+    "calingen.contrib.providers.german_holidays",
     "debug_toolbar",
 ]
 

--- a/tests/util/settings_dev.py
+++ b/tests/util/settings_dev.py
@@ -43,10 +43,6 @@ MIDDLEWARE = [
     )
 ]
 
-CALINGEN_EXTERNAL_EVENT_PROVIDER = [
-    "calingen.contrib.providers.german_holidays",
-]
-
 CALINGEN_COMPILER = {
     "default": "calingen.contrib.compilers.copy_paste.compiler.CopyPasteCompiler",
     "html": "calingen.contrib.compilers.html_or_download.compiler.HtmlOrDownloadCompiler",


### PR DESCRIPTION
**Abstract**
Make ``EventProvider`` implementations stand-alone applications (#49).

**Steps**
- [x] Convert ``calingen.contrib.providers.german_holidays`` to an actual Django app
  - ~~There are 17 dedicated ``EventProvider`` in this package. Possibly enable activation of them by a setting.~~ Does not work, the import chain provides all classes. Don't waste time on this.
- [x] Get rid of ``calingen.settings.CALINGEN_EXTERNAL_EVENT_PROVIDER``
- [x] Adjust **documentation** accordingly
- [x] Have a look at ``calingen.settings.CALINGEN_MISSING_EVENT_PROVIDER_NOTIFICATION``
  - [x] Does it work with the new way of providing ``EventProvider``?